### PR TITLE
removing deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 var through = require('through2');
-var gutil = require('gulp-util')
 var unzip = require('unzipper')
 var fs = require('fs')
 var defaults = require('defaults')
+var fancyLog = require('fancy-log')
+var Vinyl = require('vinyl')
 
 module.exports = function(options){
   function transform(file, enc, callback){
@@ -28,12 +29,12 @@ module.exports = function(options){
         }
 
         entry.pipe(through.obj(function(chunk, enc, cb){
-          // gutil.log("Find file: "+ entry.path)
+          // fancyLog("Find file: "+ entry.path)
           chunks.push(chunk)
           cb()
         }, function(cb){
           if(entry.type == 'File' && (chunks.length > 0 || opts.keepEmpty)){
-            self.push(new gutil.File({
+            self.push(new Vinyl({
               cwd : "./",
               path : entry.path,
               contents: Buffer.concat(chunks)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-unzip",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "gulp plugin for unzip",
   "main": "index.js",
   "repository": {
@@ -20,9 +20,10 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "defaults": "^1.0.0",
-    "gulp-util": "^2.2.14",
+    "fancy-log": "^1.3.2",
     "through2": "^0.4.1",
-    "unzipper": "^0.7.1"
+    "unzipper": "^0.7.1",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "mocha": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fancy-log": "^1.3.2",
     "through2": "^0.4.1",
     "unzipper": "^0.7.1",
-    "vinyl": "^2.1.0"
+    "vinyl": "^1.2.0"
   },
   "devDependencies": {
     "mocha": "^1.18.0",

--- a/test.js
+++ b/test.js
@@ -1,15 +1,15 @@
 var unzip = require('./index.js')
-var gutil = require('gulp-util')
 var fs = require('fs')
 var assert = require('assert-plus')
 var pj = require('path').join;
 var minimatch = require('minimatch')
+var Vinyl = require('vinyl');
 
 function createVinyl(filename, contents) {
   var base = pj(__dirname, 'fixture');
   var filePath = pj(base, filename);
 
-  return new gutil.File({
+  return new Vinyl({
     cwd: __dirname,
     base: base,
     path: filePath,
@@ -20,7 +20,7 @@ function createVinyl(filename, contents) {
 describe('gulp-unzip', function(){
   it("null file", function(done){
     var stream = unzip()
-    var mock = new gutil.File()
+    var mock = new Vinyl()
     stream.on('data', function(file){
       assert.deepEqual(file, mock)
       done()


### PR DESCRIPTION
fixes https://github.com/inuscript/gulp-unzip/issues/18


gulp-util has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the latest release of Gulp 4 so it is important to replace gulp-util.

The README.md lists alternatives for all the components so a simple replacement should be enough.

Your package is popular but still relying on gulp-util, it would be good to publish a fixed version to npm as soon as possible.

See:

https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
gulpjs/gulp-util#143